### PR TITLE
Fix typo

### DIFF
--- a/src/GUI.cpp
+++ b/src/GUI.cpp
@@ -25,7 +25,7 @@ static constexpr EnumStringArray<spdlog::level::level_enum, 7> LOG_LEVEL_ITEMS{
 static constexpr EnumStringArray<Position, static_cast<size_t>(Position::WindowRelative) + 1> POSITION_ITEMS{
 	"manual", "screen relative", "window relative"};
 static constexpr EnumStringArray<CornerPosition, static_cast<size_t>(CornerPosition::BottomRight) + 1> CORNER_POSITION_ITEMS{
-	"top-left", "top-right", "botttom-left", "bottom-right"};
+	"top-left", "top-right", "bottom-left", "bottom-right"};
 
 static void Display_DetailsWindow(HealWindowContext& pContext, DetailsWindowState& pState, DataSource pDataSource)
 {


### PR DESCRIPTION
Fix typo in the UI as "bottom-left" was spelled with 3 t (botttom)