### PR TITLE
Allow to resize details window

### DIFF
--- a/src/GUI.cpp
+++ b/src/GUI.cpp
@@ -39,7 +39,7 @@ static void Display_DetailsWindow(HealWindowContext& pContext, DetailsWindowStat
 	// in turn means that the name of the window can change if necessary)
 	snprintf(buffer, sizeof(buffer), "%s###HEALDETAILS.%i.%llu", pState.Name.c_str(), static_cast<int>(pDataSource), pState.Id);
 	ImGui::SetNextWindowSize(ImVec2(600, 360), ImGuiCond_FirstUseEver);
-	ImGui::Begin(buffer, &pState.IsOpen, ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoNavFocus);
+	ImGui::Begin(buffer, &pState.IsOpen, ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoNavFocus);
 
 	if (ImGui::BeginPopupContextWindow("Options##HEAL") == true)
 	{


### PR DESCRIPTION
Allow to resize the details window and save the position and size settings.

This is very much needed with 4k resolution where the default size clips the text with the numbers:
![image](https://github.com/user-attachments/assets/85bb99b9-4e1a-4db3-96cd-9c24e3346c6d)

In addition to this, it makes sense to allow players to decide which size the windows should have.