### PR TITLE
Each window has its own details window

### DIFF
--- a/src/GUI.cpp
+++ b/src/GUI.cpp
@@ -37,7 +37,7 @@ static void Display_DetailsWindow(HealWindowContext& pContext, DetailsWindowStat
 	char buffer[1024];
 	// Using "###" means the id of the window is calculated only from the part after the hashes (which
 	// in turn means that the name of the window can change if necessary)
-	snprintf(buffer, sizeof(buffer), "%s###HEALDETAILS.%i.%llu", pState.Name.c_str(), static_cast<int>(pDataSource), pState.Id);
+	snprintf(buffer, sizeof(buffer), "%s###HEALDETAILS.%u.%i.%llu", pState.Name.c_str(), pContext.WindowId, static_cast<int>(pDataSource), pState.Id);
 	ImGui::SetNextWindowSize(ImVec2(600, 360), ImGuiCond_FirstUseEver);
 	ImGui::Begin(buffer, &pState.IsOpen, ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoNavFocus);
 
@@ -74,7 +74,7 @@ static void Display_DetailsWindow(HealWindowContext& pContext, DetailsWindowStat
 	ImVec4 bgColor = ImGui::GetStyle().Colors[ImGuiCol_WindowBg];
 	bgColor.w = 0.0f;
 	ImGui::PushStyleColor(ImGuiCol_ChildBg, bgColor);
-	snprintf(buffer, sizeof(buffer), "##HEALDETAILS.TOTALS.%i.%llu", static_cast<int>(pDataSource), pState.Id);
+	snprintf(buffer, sizeof(buffer), "##HEALDETAILS.%u.TOTALS.%i.%llu", pContext.WindowId, static_cast<int>(pDataSource), pState.Id);
 	ImGui::BeginChild(buffer, ImVec2(pState.LastFrameLeftSideMinWidth, 0));
 
 	pState.LastFrameLeftSideMinWidth = 0;
@@ -145,7 +145,7 @@ static void Display_DetailsWindow(HealWindowContext& pContext, DetailsWindowStat
 	ImGuiEx::BottomText("id %u", pState.Id);
 	ImGui::EndChild();
 
-	snprintf(buffer, sizeof(buffer), "##HEALDETAILS.ENTRIES.%i.%llu", static_cast<int>(pDataSource), pState.Id);
+	snprintf(buffer, sizeof(buffer), "##HEALDETAILS.%u.ENTRIES.%i.%llu", pContext.WindowId, static_cast<int>(pDataSource), pState.Id);
 	ImGui::SameLine();
 	ImGui::BeginChild(buffer, ImVec2(0, 0));
 


### PR DESCRIPTION
Open different details windows when clicking on the same player on different windows, as they might have different exclusion settings and the data displayed would be different.

![image](https://github.com/user-attachments/assets/9277f2bc-9413-4685-9edd-d61818565fc0)

Before the data would be added to the same window, causing weird quirks, duplicating the child elements. This was not noticed before barrier and pretty much none had 2 healing stats windows open at the same time but it's easier for any player to spot as one might have a barrier-only window and a healing-only window.