### PR TITLE
Set max name length to -1 to hide player names

### DIFF
--- a/src/GUI.cpp
+++ b/src/GUI.cpp
@@ -451,6 +451,10 @@ static void Display_ContentSingleRow(HealWindowContext& pContext, DataSource pDa
 	{
 		name = utf8_substr(name, pContext.MaxNameLength);
 	}
+	else if (pContext.MaxNameLength < 0)
+	{
+		name = "";
+	}
 
 	/* Conditions to show the row:
 	* - OR: pTop is set to true. This is used by "self on top" and called only with SelfUniqueId as entry
@@ -761,7 +765,7 @@ static void Display_WindowOptions(HealTableOptions& pHealingOptions, HealWindowC
 			ImGui::SetNextItemWidth(39.0f);
 			ImGuiEx::SmallInputInt("max name length", &pContext.MaxNameLength);
 			ImGuiEx::AddTooltipToLastItem(
-				"Truncate displayed names to this many characters. Set to 0 to disable.");
+				"Truncate displayed names to this many characters. Set to 0 to disable, -1 to hide");
 
 			ImGui::SetNextItemWidth(39.0f);
 			ImGuiEx::SmallInputInt("min displayed", &pContext.MinLinesDisplayed);

--- a/src/State.h
+++ b/src/State.h
@@ -91,7 +91,7 @@ struct HealWindowOptions
 	ImGuiID AnchorWindowId = 0;
 
 	bool AutoResize = false;
-	size_t MaxNameLength = 0;
+	int64_t MaxNameLength = 0;
 	size_t MinLinesDisplayed = 0;
 	size_t MaxLinesDisplayed = 10;
 	size_t FixedWindowWidth = 400;


### PR DESCRIPTION
Set max name length to -1 to hide player names

This is the same behavior as ArcDps

Window on the top is ArcDps, on the bottom is healing stats
<img width="302" height="227" alt="image" src="https://github.com/user-attachments/assets/fcd522e3-e386-48c8-a046-aedcfa74f169" />
