### PR TITLE
Max name length option doesn't affect skill name length in the details window anymore

### DIFF
--- a/src/GUI.cpp
+++ b/src/GUI.cpp
@@ -403,10 +403,6 @@ static void Display_DetailsWindow(HealWindowContext& pContext, DetailsWindowStat
 		float barrierGenerationRatio = static_cast<float>(divide_safe(entry.BarrierGeneration, stats.HighestHealing));
 
 		std::string_view name = entry.Agent.Name;
-		if (pContext.MaxNameLength > 0)
-		{
-			name = utf8_substr(name, pContext.MaxNameLength);
-		}
 		pState.LastFrameRightSideMinWidth = (std::max)(
 			pState.LastFrameRightSideMinWidth,
 			ImGuiEx::StatsEntry(name, buffer, pContext.ShowProgressBars == true ? std::optional{healingRatio} : std::nullopt, pContext.ShowProgressBars == true ? std::optional{ barrierGenerationRatio } : std::nullopt, std::nullopt, std::nullopt, nullptr, std::nullopt, std::nullopt, std::nullopt, false));


### PR DESCRIPTION
Max name length option doesn't affect skill name length in the details window anymore

Setting the option to 5, you can see that the main window shows only "Jackp" (full char name is "Jackpoz") and the skill names are not shortened ("Regeneration" and "Tome of Resolve")
<img width="991" height="166" alt="image" src="https://github.com/user-attachments/assets/8765b440-faa3-41be-8204-e04b0d2a2a7d" />
