### PR TITLE
Update to latest arcdps version

### DIFF
--- a/src/Exports.h
+++ b/src/Exports.h
@@ -47,5 +47,5 @@ public:
 
 typedef void* (*MallocSignature)(size_t);
 typedef void (*FreeSignature)(void*);
-extern "C" __declspec(dllexport) ModInitSignature get_init_addr(const char* pArcdpsVersionString, void* pImguiContext, void* pID3DPtr, HMODULE pArcModule, MallocSignature pArcdpsMalloc, FreeSignature pArcdpsFree, uint32_t pD3DVersion);
+extern "C" __declspec(dllexport) ModInitSignature get_init_addr(const char* pArcdpsVersionString, void* pImguiContext, void* pID3DPtr, HMODULE pArcModule, MallocSignature pArcdpsMalloc, FreeSignature pArcdpsFree, uint32_t pImGuiVersion);
 extern "C" __declspec(dllexport) ModReleaseSignature get_release_addr();

--- a/src/GUI.cpp
+++ b/src/GUI.cpp
@@ -103,10 +103,10 @@ static const HealedAgent AnonymousAgent{
 	0, "", "", 0, false, true, Prof::PROF_UNKNOWN, 0xFFFFFFFF
 };
 
-void LoadIcons(HMODULE pCurrentModule, void* pID3DPtr, uint32_t pD3DVersion)
+void LoadIcons(HMODULE pCurrentModule, void* pID3DPtr, uint32_t pImGuiVersion)
 {
 	ID3D11Device* d3d11 = nullptr;
-	if (pD3DVersion == 11)
+	if (pImGuiVersion != 0)
 	{
 		IDXGISwapChain* d3d11SwapChain = static_cast<IDXGISwapChain*>(pID3DPtr);
 		d3d11SwapChain->GetDevice(__uuidof(d3d11), (void**)&d3d11);

--- a/src/GUI.h
+++ b/src/GUI.h
@@ -6,7 +6,7 @@
 
 void SetContext(void* pImGuiContext);
 void FindAndResolveCyclicDependencies(HealTableOptions& pHealingOptions, size_t pStartIndex);
-void LoadIcons(HMODULE pArcModule, void* pID3DPtr, uint32_t pD3DVersion);
+void LoadIcons(HMODULE pArcModule, void* pID3DPtr, uint32_t pImGuiVersion);
 
 void Display_GUI(HealTableOptions& pHealingOptions);
 void Display_AddonOptions(HealTableOptions& pHealingOptions);

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -132,7 +132,7 @@ static void FreeWrapper(void* pPointer, void* /*pUserData*/)
 }
 
 /* export -- arcdps looks for this exported function and calls the address it returns on client load */
-extern "C" __declspec(dllexport) ModInitSignature get_init_addr(const char* pArcdpsVersionString, void* pImguiContext, void* pID3DPtr, HMODULE pArcModule , MallocSignature pArcdpsMalloc, FreeSignature pArcdpsFree, uint32_t pD3DVersion)
+extern "C" __declspec(dllexport) ModInitSignature get_init_addr(const char* pArcdpsVersionString, void* pImguiContext, void* pID3DPtr, HMODULE pArcModule , MallocSignature pArcdpsMalloc, FreeSignature pArcdpsFree, uint32_t pImGuiVersion)
 {
 	GlobalObjects::ARC_E3 = reinterpret_cast<E3Signature>(GetProcAddress(pArcModule, "e3"));
 	assert(GlobalObjects::ARC_E3 != nullptr);
@@ -164,7 +164,7 @@ extern "C" __declspec(dllexport) ModInitSignature get_init_addr(const char* pArc
 		ImGui::AddContextHook(reinterpret_cast<ImGuiContext*>(pImguiContext), &contextHook);
 	}
 
-	LoadIcons(GlobalObjects::SELF_HANDLE, pID3DPtr, pD3DVersion);
+	LoadIcons(GlobalObjects::SELF_HANDLE, pID3DPtr, pImGuiVersion);
 
 	return mod_init;
 }


### PR DESCRIPTION
Arcdps passes ImGui version instead of D3D version. See https://discord.com/channels/456611641526845473/799665481618554900/1500840421792944264

The `!= 0` check is kept for unit tests.