### PR TITLE
Add missing D3D buffer release

### DIFF
--- a/src/GUI.cpp
+++ b/src/GUI.cpp
@@ -126,6 +126,8 @@ ID3D11Device* GetD3DDevice(void* pID3DPtr)
 		id3d11d = bbid3d11d;
 	}
 
+	backBuffer->Release();
+
 	return id3d11d;
 }
 


### PR DESCRIPTION
Add missing D3D buffer release. This was causing a black screen when resizing GW2, for example when pressing Alt+Enter