### PR TITLE
Use CComPtr instead of raw pointers with D3D

### DIFF
--- a/src/GUI.cpp
+++ b/src/GUI.cpp
@@ -103,46 +103,45 @@ static const HealedAgent AnonymousAgent{
 	0, "", "", 0, false, true, Prof::PROF_UNKNOWN, 0xFFFFFFFF
 };
 
-ID3D11Device* GetD3DDevice(void* pID3DPtr)
+CComPtr<ID3D11Device> id3d11d = nullptr;
+
+void GetD3DDevice(void* pID3DPtr)
 {
 	auto swapChain = static_cast<IDXGISwapChain*>(pID3DPtr);
-	ID3D11Device* id3d11d = nullptr;
-	if (FAILED(swapChain->GetDevice(__uuidof(id3d11d), reinterpret_cast<void**>(&id3d11d)))) {
+	if (FAILED(swapChain->GetDevice(IID_PPV_ARGS(&id3d11d))))
+	{
 		GlobalObjects::ARC_E3("Healing Stats: Failed to get D3D device");
 		id3d11d = nullptr;
 	}
 
-	ID3D11Texture2D* backBuffer = nullptr;
-	if (FAILED(swapChain->GetBuffer(0, __uuidof(backBuffer), reinterpret_cast<void**>(&backBuffer)))) {
+	CComPtr<ID3D11Texture2D> backBuffer = nullptr;
+	if (FAILED(swapChain->GetBuffer(0, IID_PPV_ARGS(&backBuffer))))
+	{
 		GlobalObjects::ARC_E3("Healing Stats: Failed to get backbuffer");
-		return nullptr;
+		return;
 	}
 
-	ID3D11Device* bbid3d11d = nullptr;
+	CComPtr<ID3D11Device> bbid3d11d = nullptr;
 	backBuffer->GetDevice(&bbid3d11d);
 
-	if (bbid3d11d && id3d11d != bbid3d11d) {
+	if (bbid3d11d && id3d11d != bbid3d11d)
+	{
 		GlobalObjects::ARC_E3("Healing Stats: SmoothMotion workaround");
 		id3d11d = bbid3d11d;
 	}
-
-	backBuffer->Release();
-
-	return id3d11d;
 }
 
 void LoadIcons(HMODULE pCurrentModule, void* pID3DPtr, uint32_t pImGuiVersion)
 {
-	ID3D11Device* d3d11 = nullptr;
 	if (pImGuiVersion != 0)
 	{
-		d3d11 = GetD3DDevice(pID3DPtr);
+		GetD3DDevice(pID3DPtr);
 	}
 
-	auto& iconLoader = ArcdpsExtension::IconLoader::init(pCurrentModule, d3d11);
+	auto& iconLoader = ArcdpsExtension::IconLoader::init(pCurrentModule, id3d11d);
 
 	// This happens only in unit tests
-	if (d3d11 == nullptr)
+	if (id3d11d == nullptr)
 	{
 		return;
 	}


### PR DESCRIPTION
Use CComPtr instead of raw pointers with D3D. This aligns with the code used in Boon Table.

Leaving this as draft until no more changes are done to Boon Table version.