### PR TITLE
Add "against downed" exclusion option

### DIFF
--- a/src/AggregatedStats.cpp
+++ b/src/AggregatedStats.cpp
@@ -114,13 +114,26 @@ const AggregatedVector& AggregatedStats::GetGroupFilterTotals()
 			continue;
 		}
 
-		if (curEvent.IsBarrierGeneration && myOptions.ExcludeBarrierGeneration == true)
+		if (curEvent.IsAgainstDowned)
 		{
-			continue;
+			if (myOptions.ExcludeAgainstDowned == true)
+			{
+				continue;
+			}
 		}
-		else if (!curEvent.IsBarrierGeneration && myOptions.ExcludeHealing == true)
+		else if (curEvent.IsBarrierGeneration)
 		{
-			continue;
+			if (myOptions.ExcludeBarrierGeneration == true)
+			{
+				continue;
+			}
+		}
+		else // Healing
+		{
+			if (myOptions.ExcludeHealing == true)
+			{
+				continue;
+			}
 		}
 
 		auto mapAgent = std::as_const(mySourceData.Agents).find(curEvent.AgentId);
@@ -313,13 +326,26 @@ const AggregatedVector& AggregatedStats::GetAgents(std::optional<uint32_t> pSkil
 			continue;
 		}
 
-		if (curEvent.IsBarrierGeneration && myOptions.ExcludeBarrierGeneration == true)
+		if (curEvent.IsAgainstDowned)
 		{
-			continue;
+			if (myOptions.ExcludeAgainstDowned == true)
+			{
+				continue;
+			}
 		}
-		else if (!curEvent.IsBarrierGeneration && myOptions.ExcludeHealing == true)
+		else if (curEvent.IsBarrierGeneration)
 		{
-			continue;
+			if (myOptions.ExcludeBarrierGeneration == true)
+			{
+				continue;
+			}
+		}
+		else // Healing
+		{
+			if (myOptions.ExcludeHealing == true)
+			{
+				continue;
+			}
 		}
 
 		if (pSkillId.has_value() == true)
@@ -346,7 +372,7 @@ const AggregatedVector& AggregatedStats::GetAgents(std::optional<uint32_t> pSkil
 		{
 			// For barrier generation hits, track the total barrier generation separately as a sub-total of healing.
 			agent->second.BarrierGeneration += curEvent.Size;
-		}			
+		}
 	}
 
 	// Caching the result in a display friendly way
@@ -443,13 +469,26 @@ const AggregatedVector& AggregatedStats::GetSkills(std::optional<uintptr_t> pAge
 			continue;
 		}
 
-		if (curEvent.IsBarrierGeneration && myOptions.ExcludeBarrierGeneration == true)
+		if (curEvent.IsAgainstDowned)
 		{
-			continue;
+			if (myOptions.ExcludeAgainstDowned == true)
+			{
+				continue;
+			}
 		}
-		else if (!curEvent.IsBarrierGeneration && myOptions.ExcludeHealing == true)
+		else if (curEvent.IsBarrierGeneration)
 		{
-			continue;
+			if (myOptions.ExcludeBarrierGeneration == true)
+			{
+				continue;
+			}
+		}
+		else // Healing
+		{
+			if (myOptions.ExcludeHealing == true)
+			{
+				continue;
+			}
 		}
 
 		if (pAgentId.has_value() == true)

--- a/src/GUI.cpp
+++ b/src/GUI.cpp
@@ -725,6 +725,7 @@ static void Display_WindowOptions(HealTableOptions& pHealingOptions, HealWindowC
 
 			ImGuiEx::SmallCheckBox("healing", &pContext.ExcludeHealing);
 			ImGuiEx::SmallCheckBox("barrier generation", &pContext.ExcludeBarrierGeneration);
+			ImGuiEx::SmallCheckBox("against downed", &pContext.ExcludeAgainstDowned);
 
 			ImGui::EndMenu();
 		}

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -132,6 +132,7 @@ HealTableOptions::HealTableOptions()
 	Windows[6].DataSourceChoice = DataSource::PeersOutgoing;
 	Windows[6].ExcludeHealing = true;
 	Windows[6].ExcludeBarrierGeneration = false;
+	Windows[6].ExcludeAgainstDowned = true;
 	snprintf(Windows[6].Name, sizeof(Windows[6].Name), "%s", "Peers barrier generation");
 	snprintf(Windows[6].TitleFormat, sizeof(Windows[6].TitleFormat), "%s", "Barrier generation {1} ({4}/s, {7}s in combat)");
 
@@ -430,9 +431,10 @@ void HealWindowOptions::FromJson(const nlohmann::json& pJsonObject)
 	GetJsonValue(pJsonObject, "ExcludeOffGroup", ExcludeOffGroup);
 	GetJsonValue(pJsonObject, "ExcludeOffSquad", ExcludeOffSquad);
 	GetJsonValue(pJsonObject, "ExcludeMinions", ExcludeMinions);
-	GetJsonValue(pJsonObject,  "ExcludeUnmapped", ExcludeUnmapped);
+	GetJsonValue(pJsonObject, "ExcludeUnmapped", ExcludeUnmapped);
 	GetJsonValue(pJsonObject, "ExcludeHealing", ExcludeHealing);
 	GetJsonValue(pJsonObject, "ExcludeBarrierGeneration", ExcludeBarrierGeneration);
+	GetJsonValue(pJsonObject, "ExcludeAgainstDowned", ExcludeAgainstDowned);
 
 	GetJsonValue(pJsonObject, "ShowProgressBars", ShowProgressBars);
 	GetJsonValue(pJsonObject, "UseSubgroupForBarColour", UseSubgroupForBarColour);
@@ -500,6 +502,7 @@ do {\
 	SET_JSON_VAL(ExcludeUnmapped);
 	SET_JSON_VAL(ExcludeHealing);
 	SET_JSON_VAL(ExcludeBarrierGeneration);
+	SET_JSON_VAL(ExcludeAgainstDowned);
 
 	SET_JSON_VAL(ShowProgressBars);
 	SET_JSON_VAL(UseSubgroupForBarColour);

--- a/src/PlayerStats.cpp
+++ b/src/PlayerStats.cpp
@@ -6,18 +6,19 @@
 #include <assert.h>
 #include <Windows.h>
 
-HealEvent::HealEvent(uint64_t pTime, uint64_t pSize, uintptr_t pAgentId, uint32_t pSkillId, bool pIsBarrierGeneration)
+HealEvent::HealEvent(uint64_t pTime, uint64_t pSize, uintptr_t pAgentId, uint32_t pSkillId, bool pIsBarrierGeneration, bool pIsAgainstDowned)
 	: Time{pTime}
 	, Size{pSize}
 	, AgentId{pAgentId}
 	, SkillId{pSkillId}
 	, IsBarrierGeneration{pIsBarrierGeneration}
+	, IsAgainstDowned{pIsAgainstDowned}
 {
 }
 
 bool HealEvent::operator==(const HealEvent& pRight) const
 {
-	return std::tie(Time, Size, AgentId, SkillId, IsBarrierGeneration) == std::tie(pRight.Time, pRight.Size, pRight.AgentId, pRight.SkillId, pRight.IsBarrierGeneration);
+	return std::tie(Time, Size, AgentId, SkillId, IsBarrierGeneration, IsAgainstDowned) == std::tie(pRight.Time, pRight.Size, pRight.AgentId, pRight.SkillId, pRight.IsBarrierGeneration, pRight.IsAgainstDowned);
 }
 
 bool HealEvent::operator!=(const HealEvent& pRight) const
@@ -117,6 +118,8 @@ void PlayerStats::HealingEvent(cbtevent* pEvent, uintptr_t pDestinationAgentId)
 		assert(healedAmount != 0);
 	}
 
+	bool isAgainstDowned = pEvent->is_offcycle == 1;
+
 	{
 		std::lock_guard<std::mutex> lock(myLock);
 
@@ -126,7 +129,7 @@ void PlayerStats::HealingEvent(cbtevent* pEvent, uintptr_t pDestinationAgentId)
 			return;
 		}
 
-		myStats.Events.emplace_back(pEvent->time, healedAmount, pDestinationAgentId, pEvent->skillid, false);
+		myStats.Events.emplace_back(pEvent->time, healedAmount, pDestinationAgentId, pEvent->skillid, false, isAgainstDowned);
 	}
 }
 
@@ -139,6 +142,8 @@ void PlayerStats::BarrierGenerationEvent(cbtevent* pEvent, uintptr_t pDestinatio
 		assert(barrierGenerationAmount != 0);
 	}
 
+	bool isAgainstDowned = pEvent->is_offcycle == 1;
+
 	{
 		std::lock_guard<std::mutex> lock(myLock);
 
@@ -148,7 +153,7 @@ void PlayerStats::BarrierGenerationEvent(cbtevent* pEvent, uintptr_t pDestinatio
 			return;
 		}
 
-		myStats.Events.emplace_back(pEvent->time, barrierGenerationAmount, pDestinationAgentId, pEvent->skillid, true);
+		myStats.Events.emplace_back(pEvent->time, barrierGenerationAmount, pDestinationAgentId, pEvent->skillid, true, isAgainstDowned);
 	}
 }
 

--- a/src/PlayerStats.h
+++ b/src/PlayerStats.h
@@ -16,8 +16,9 @@ struct HealEvent
 	const uintptr_t AgentId = 0;
 	const uint32_t SkillId = 0;
 	const bool IsBarrierGeneration = false;
+	const bool IsAgainstDowned = false;
 
-	HealEvent(uint64_t pTime, uint64_t pSize, uintptr_t pAgentId, uint32_t pSkillId, bool pIsBarrierGeneration);
+	HealEvent(uint64_t pTime, uint64_t pSize, uintptr_t pAgentId, uint32_t pSkillId, bool pIsBarrierGeneration, bool pIsAgainstDowned);
 
 	bool operator==(const HealEvent& pRight) const;
 	bool operator!=(const HealEvent& pRight) const;

--- a/src/State.h
+++ b/src/State.h
@@ -59,6 +59,7 @@ struct HealWindowOptions
 	bool ExcludeUnmapped = true;
 	bool ExcludeHealing = false;
 	bool ExcludeBarrierGeneration = true;
+	bool ExcludeAgainstDowned = false;
 
 	bool ShowProgressBars = true;
 	bool UseSubgroupForBarColour = false;

--- a/test/ConfigTest.cpp
+++ b/test/ConfigTest.cpp
@@ -69,6 +69,7 @@ TEST(ConfigTest, Serialize_Deserialize)
 		window.ExcludeUnmapped = rand_t<bool>();
 		window.ExcludeHealing = rand_t<bool>();
 		window.ExcludeBarrierGeneration = rand_t<bool>();
+		window.ExcludeAgainstDowned = rand_t<bool>();
 
 		window.ShowProgressBars = rand_t<bool>();
 		window.UseSubgroupForBarColour = rand_t<bool>();
@@ -138,6 +139,7 @@ TEST(ConfigTest, Serialize_Deserialize)
 		ASSERT_EQ(windowLeft.ExcludeUnmapped, windowRight.ExcludeUnmapped);
 		ASSERT_EQ(windowLeft.ExcludeHealing, windowRight.ExcludeHealing);
 		ASSERT_EQ(windowLeft.ExcludeBarrierGeneration, windowRight.ExcludeBarrierGeneration);
+		ASSERT_EQ(windowLeft.ExcludeAgainstDowned, windowRight.ExcludeAgainstDowned);
 
 		ASSERT_EQ(windowLeft.ShowProgressBars, windowRight.ShowProgressBars);
 		ASSERT_EQ(windowLeft.UseSubgroupForBarColour, windowRight.UseSubgroupForBarColour);


### PR DESCRIPTION
Add "against downed" exclusion option:
<img width="318" height="187" alt="image" src="https://github.com/user-attachments/assets/0c442148-8ccf-4d69-96e3-e3bc8e3344af" />

"healing" and "barrier" now excludes only against alive targets.

This allows to manually create windows with just healing and barrier against alive targets, without big jumps in HPS caused by skills like https://wiki.guildwars2.com/wiki/Spirit_of_Nature
<img width="401" height="220" alt="image" src="https://github.com/user-attachments/assets/7f517009-c709-4d44-85ea-a293debe41e4" />
