### PR TITLE
Add new option "all but skill ids" in stats exclude

### DIFF
--- a/src/AggregatedStats.cpp
+++ b/src/AggregatedStats.cpp
@@ -136,6 +136,11 @@ const AggregatedVector& AggregatedStats::GetGroupFilterTotals()
 			}
 		}
 
+		if (FilterSkill(curEvent.SkillId))
+		{
+			continue;
+		}
+
 		auto mapAgent = std::as_const(mySourceData.Agents).find(curEvent.AgentId);
 
 		// Loop through the array and pretend index is GroupFilter, if agent does not get filtered by that filter then add
@@ -356,6 +361,11 @@ const AggregatedVector& AggregatedStats::GetAgents(std::optional<uint32_t> pSkil
 			}
 		}
 
+		if (FilterSkill(curEvent.SkillId))
+		{
+			continue;
+		}
+
 		auto mapAgent = std::as_const(mySourceData.Agents).find(curEvent.AgentId);
 		if (Filter(mapAgent) == true)
 		{
@@ -489,6 +499,11 @@ const AggregatedVector& AggregatedStats::GetSkills(std::optional<uintptr_t> pAge
 			{
 				continue;
 			}
+		}
+
+		if (FilterSkill(curEvent.SkillId))
+		{
+			continue;
 		}
 
 		if (pAgentId.has_value() == true)
@@ -691,3 +706,14 @@ bool AggregatedStats::FilterInternal(std::map<uintptr_t, HealedAgent>::const_ite
 
 	return false;
 }
+
+bool AggregatedStats::FilterSkill(uint32_t pSkillId) const
+{
+	auto parsedSkills = ParseUInt32String(std::string_view(myOptions.IncludedSkills));
+	if (parsedSkills.empty())
+	{
+		return false;
+	}
+
+	return !std::ranges::contains(parsedSkills, pSkillId);
+}	

--- a/src/AggregatedStats.cpp
+++ b/src/AggregatedStats.cpp
@@ -106,6 +106,7 @@ const AggregatedVector& AggregatedStats::GetGroupFilterTotals()
 	HealWindowOptions fakeOptions;
 
 	uint64_t combatEnd = GetCombatEnd();
+	auto includedSkills = GetIncludedSkills();
 
 	for (const HealEvent& curEvent : mySourceData.Events)
 	{
@@ -136,7 +137,7 @@ const AggregatedVector& AggregatedStats::GetGroupFilterTotals()
 			}
 		}
 
-		if (FilterSkill(curEvent.SkillId))
+		if (FilterSkill(curEvent.SkillId, includedSkills))
 		{
 			continue;
 		}
@@ -323,6 +324,7 @@ const AggregatedVector& AggregatedStats::GetAgents(std::optional<uint32_t> pSkil
 	std::map<uintptr_t, TempAgent> tempMap;
 
 	uint64_t combatEnd = GetCombatEnd();
+	auto includedSkills = GetIncludedSkills();
 
 	for (const HealEvent& curEvent : mySourceData.Events)
 	{
@@ -361,7 +363,7 @@ const AggregatedVector& AggregatedStats::GetAgents(std::optional<uint32_t> pSkil
 			}
 		}
 
-		if (FilterSkill(curEvent.SkillId))
+		if (FilterSkill(curEvent.SkillId, includedSkills))
 		{
 			continue;
 		}
@@ -468,6 +470,7 @@ const AggregatedVector& AggregatedStats::GetSkills(std::optional<uintptr_t> pAge
 	std::map<uint32_t, TempSkill> tempMap;
 
 	uint64_t combatEnd = GetCombatEnd();
+	auto includedSkills = GetIncludedSkills();
 	uint64_t totalIndirectHealing = 0;
 	uint64_t totalIndirectTicks = 0;
 	uint64_t totalIndirectBarrierGeneration = 0;
@@ -501,7 +504,7 @@ const AggregatedVector& AggregatedStats::GetSkills(std::optional<uintptr_t> pAge
 			}
 		}
 
-		if (FilterSkill(curEvent.SkillId))
+		if (FilterSkill(curEvent.SkillId, includedSkills))
 		{
 			continue;
 		}
@@ -707,13 +710,17 @@ bool AggregatedStats::FilterInternal(std::map<uintptr_t, HealedAgent>::const_ite
 	return false;
 }
 
-bool AggregatedStats::FilterSkill(uint32_t pSkillId) const
+bool AggregatedStats::FilterSkill(uint32_t pSkillId, std::vector<uint32_t>& pIncludedSkills) const
 {
-	auto parsedSkills = ParseUInt32String(std::string_view(myOptions.IncludedSkills));
-	if (parsedSkills.empty())
+	if (pIncludedSkills.empty())
 	{
 		return false;
 	}
 
-	return !std::ranges::contains(parsedSkills, pSkillId);
-}	
+	return !std::ranges::contains(pIncludedSkills, pSkillId);
+}
+
+std::vector<uint32_t> AggregatedStats::GetIncludedSkills() const
+{
+	return ParseUInt32String(std::string_view(myOptions.IncludedSkills));
+}

--- a/src/AggregatedStats.h
+++ b/src/AggregatedStats.h
@@ -78,6 +78,7 @@ private:
 	bool Filter(uintptr_t pAgentId) const; // Returns true if agent should be filtered out
 	bool Filter(std::map<uintptr_t, HealedAgent>::const_iterator& pAgent) const; // Returns true if agent should be filtered out
 	bool FilterInternal(std::map<uintptr_t, HealedAgent>::const_iterator& pAgent, const HealWindowOptions& pFilter) const; // Returns true if agent should be filtered out
+	bool FilterSkill(uint32_t pSkillId) const; // Returns true if skill should be filtered out
 
 	HealingStats mySourceData;
 

--- a/src/AggregatedStats.h
+++ b/src/AggregatedStats.h
@@ -78,7 +78,8 @@ private:
 	bool Filter(uintptr_t pAgentId) const; // Returns true if agent should be filtered out
 	bool Filter(std::map<uintptr_t, HealedAgent>::const_iterator& pAgent) const; // Returns true if agent should be filtered out
 	bool FilterInternal(std::map<uintptr_t, HealedAgent>::const_iterator& pAgent, const HealWindowOptions& pFilter) const; // Returns true if agent should be filtered out
-	bool FilterSkill(uint32_t pSkillId) const; // Returns true if skill should be filtered out
+	bool FilterSkill(uint32_t pSkillId, std::vector<uint32_t>& pIncludedSkills) const; // Returns true if skill should be filtered out
+	std::vector<uint32_t> GetIncludedSkills() const;
 
 	HealingStats mySourceData;
 

--- a/src/GUI.cpp
+++ b/src/GUI.cpp
@@ -726,8 +726,8 @@ static void Display_WindowOptions(HealTableOptions& pHealingOptions, HealWindowC
 			ImGuiEx::SmallCheckBox("healing", &pContext.ExcludeHealing);
 			ImGuiEx::SmallCheckBox("barrier generation", &pContext.ExcludeBarrierGeneration);
 			ImGuiEx::SmallCheckBox("against downed", &pContext.ExcludeAgainstDowned);
-			ImGuiEx::SmallInputText("included skills", pContext.IncludedSkills, sizeof(pContext.IncludedSkills));
-			ImGuiEx::AddTooltipToLastItem("Only these skills will be included. Write skill ids separated by a space in the format 123 456");
+			ImGuiEx::SmallInputText("all but skill ids", pContext.IncludedSkills, sizeof(pContext.IncludedSkills));
+			ImGuiEx::AddTooltipToLastItem("Only stats for these skill ids should be included in this window. Comma-separated list, e.g. \"1000,1001,2020\"");
 
 			ImGui::EndMenu();
 		}

--- a/src/GUI.cpp
+++ b/src/GUI.cpp
@@ -726,6 +726,8 @@ static void Display_WindowOptions(HealTableOptions& pHealingOptions, HealWindowC
 			ImGuiEx::SmallCheckBox("healing", &pContext.ExcludeHealing);
 			ImGuiEx::SmallCheckBox("barrier generation", &pContext.ExcludeBarrierGeneration);
 			ImGuiEx::SmallCheckBox("against downed", &pContext.ExcludeAgainstDowned);
+			ImGuiEx::SmallInputText("included skills", pContext.IncludedSkills, sizeof(pContext.IncludedSkills));
+			ImGuiEx::AddTooltipToLastItem("Only these skills will be included. Write skill ids separated by a space in the format 123 456");
 
 			ImGui::EndMenu();
 		}

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -435,6 +435,7 @@ void HealWindowOptions::FromJson(const nlohmann::json& pJsonObject)
 	GetJsonValue(pJsonObject, "ExcludeHealing", ExcludeHealing);
 	GetJsonValue(pJsonObject, "ExcludeBarrierGeneration", ExcludeBarrierGeneration);
 	GetJsonValue(pJsonObject, "ExcludeAgainstDowned", ExcludeAgainstDowned);
+	GetJsonValue(pJsonObject, "IncludedSkills", IncludedSkills);
 
 	GetJsonValue(pJsonObject, "ShowProgressBars", ShowProgressBars);
 	GetJsonValue(pJsonObject, "UseSubgroupForBarColour", UseSubgroupForBarColour);
@@ -503,6 +504,7 @@ do {\
 	SET_JSON_VAL(ExcludeHealing);
 	SET_JSON_VAL(ExcludeBarrierGeneration);
 	SET_JSON_VAL(ExcludeAgainstDowned);
+	SET_JSON_VAL_CSTR_ARRAY(IncludedSkills);
 
 	SET_JSON_VAL(ShowProgressBars);
 	SET_JSON_VAL(UseSubgroupForBarColour);

--- a/src/State.h
+++ b/src/State.h
@@ -10,6 +10,7 @@
 constexpr static uint32_t MAX_HEAL_WINDOW_NAME = 31;
 constexpr static uint32_t MAX_HEAL_WINDOW_TITLE = 127;
 constexpr static uint32_t MAX_HEAL_WINDOW_ENTRY = 127;
+constexpr static uint32_t MAX_HEAL_WINDOW_INCLUDED_SKILLS = 127;
 constexpr static uint32_t HEAL_WINDOW_COUNT = 10;
 
 enum class DataSource
@@ -78,6 +79,7 @@ struct HealWindowOptions
 	char TitleFormat[MAX_HEAL_WINDOW_TITLE + 1] = "{1} ({4}/s, {7}s in combat)";
 	char EntryFormat[MAX_HEAL_WINDOW_ENTRY + 1] = "{1} ({4}/s, {7}%)";
 	char DetailsEntryFormat[MAX_HEAL_WINDOW_ENTRY + 1] = "{1} ({4}/s, {7}%)";
+	char IncludedSkills[MAX_HEAL_WINDOW_INCLUDED_SKILLS + 1] = {};
 
 	ImGuiWindowFlags_ WindowFlags = ImGuiWindowFlags_None;
 

--- a/src/Utilities.h
+++ b/src/Utilities.h
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <array>
+#include <ranges>
 #include <string>
 #include <optional>
 #include <variant>
@@ -233,4 +234,27 @@ static inline std::string_view utf8_substr(std::string_view pStr, size_t pCharac
 	U8_FWD_N(pStr.data(), bytesToSkip, length, static_cast<int>(pCharacterCount));
 
 	return pStr.substr(0, bytesToSkip);
+}
+
+static inline std::vector<uint32_t> ParseUInt32String(std::string_view pStr)
+{
+	std::vector<uint32_t> result;
+
+	if (pStr.empty() == true)
+	{
+		return result;
+	}
+
+	for (auto&& part : pStr | std::views::split(' '))
+	{
+		uint32_t value{};
+		auto fromCharsResult = std::from_chars(&*part.begin(), &*part.end(), value);
+
+		if (fromCharsResult.ec != std::errc{} || fromCharsResult.ptr != &*part.end())
+			continue;
+
+		result.push_back(value);
+	}
+
+	return result;
 }

--- a/src/Utilities.h
+++ b/src/Utilities.h
@@ -241,11 +241,6 @@ static inline std::vector<uint32_t> ParseUInt32String(std::string_view pStr)
 {
 	std::vector<uint32_t> result;
 
-	if (pStr.empty() == true)
-	{
-		return result;
-	}
-
 	constexpr auto is_delim = [](char c)
 	{
 		return c == ',' || c == ';' || c == ' ';

--- a/src/Utilities.h
+++ b/src/Utilities.h
@@ -10,6 +10,7 @@
 #include <array>
 #include <ranges>
 #include <string>
+#include <string_view>
 #include <optional>
 #include <variant>
 
@@ -245,12 +246,28 @@ static inline std::vector<uint32_t> ParseUInt32String(std::string_view pStr)
 		return result;
 	}
 
-	for (auto&& part : pStr | std::views::split(' '))
+	constexpr auto is_delim = [](char c)
+	{
+		return c == ',' || c == ';' || c == ' ';
+	};
+
+	constexpr auto same_kind = [](char a, char b) {
+		return is_delim(a) == is_delim(b);
+	};
+
+	auto tokens = pStr
+		| std::views::chunk_by(same_kind)
+		| std::views::filter([](auto chunk) {
+			return !is_delim(*chunk.begin());
+		});
+
+	for (auto chunk : tokens)
 	{
 		uint32_t value{};
-		auto fromCharsResult = std::from_chars(&*part.begin(), &*part.end(), value);
+		std::string_view token(&*chunk.begin(), std::ranges::distance(chunk));
+		auto fromCharsResult = std::from_chars(token.data(), token.data() + token.size(), value);
 
-		if (fromCharsResult.ec != std::errc{} || fromCharsResult.ptr != &*part.end())
+		if (fromCharsResult.ec != std::errc{} || fromCharsResult.ptr != token.data() + token.size())
 			continue;
 
 		result.push_back(value);

--- a/test/ConfigTest.cpp
+++ b/test/ConfigTest.cpp
@@ -70,6 +70,7 @@ TEST(ConfigTest, Serialize_Deserialize)
 		window.ExcludeHealing = rand_t<bool>();
 		window.ExcludeBarrierGeneration = rand_t<bool>();
 		window.ExcludeAgainstDowned = rand_t<bool>();
+		rand_string(window.IncludedSkills);
 
 		window.ShowProgressBars = rand_t<bool>();
 		window.UseSubgroupForBarColour = rand_t<bool>();
@@ -140,6 +141,7 @@ TEST(ConfigTest, Serialize_Deserialize)
 		ASSERT_EQ(windowLeft.ExcludeHealing, windowRight.ExcludeHealing);
 		ASSERT_EQ(windowLeft.ExcludeBarrierGeneration, windowRight.ExcludeBarrierGeneration);
 		ASSERT_EQ(windowLeft.ExcludeAgainstDowned, windowRight.ExcludeAgainstDowned);
+		ASSERT_EQ(strcmp(windowLeft.IncludedSkills, windowRight.IncludedSkills), 0);
 
 		ASSERT_EQ(windowLeft.ShowProgressBars, windowRight.ShowProgressBars);
 		ASSERT_EQ(windowLeft.UseSubgroupForBarColour, windowRight.UseSubgroupForBarColour);

--- a/test/UtilitiesTest.cpp
+++ b/test/UtilitiesTest.cpp
@@ -38,3 +38,15 @@ TEST(UtilitiesTest, utf8_substr_unicode)
 	ASSERT_EQ(utf8_substr(sourceData, 11), "ホヽのö Wó卂丂ᗪ");
 	ASSERT_EQ(utf8_substr(sourceData, 100000000), "ホヽのö Wó卂丂ᗪ");
 }
+
+TEST(UtilitiesTest, ParseUInt32String)
+{
+	EXPECT_EQ(ParseUInt32String(""), std::vector<uint32_t>{});
+	EXPECT_EQ(ParseUInt32String(" "), std::vector<uint32_t>{});
+	EXPECT_EQ(ParseUInt32String("abc"), std::vector<uint32_t>{});
+	EXPECT_EQ(ParseUInt32String("a;b;c"), std::vector<uint32_t>{});
+	EXPECT_EQ(ParseUInt32String("1"), std::vector<uint32_t>{ 1 });
+	EXPECT_EQ(ParseUInt32String("1;2"), (std::vector<uint32_t>{ 1, 2 }));
+	EXPECT_EQ(ParseUInt32String("1; 2"), (std::vector<uint32_t>{ 1, 2 }));
+	EXPECT_EQ(ParseUInt32String("1; 2 "), (std::vector<uint32_t>{ 1, 2 }));
+}

--- a/test/UtilitiesTest.cpp
+++ b/test/UtilitiesTest.cpp
@@ -44,9 +44,11 @@ TEST(UtilitiesTest, ParseUInt32String)
 	EXPECT_EQ(ParseUInt32String(""), std::vector<uint32_t>{});
 	EXPECT_EQ(ParseUInt32String(" "), std::vector<uint32_t>{});
 	EXPECT_EQ(ParseUInt32String("abc"), std::vector<uint32_t>{});
+	EXPECT_EQ(ParseUInt32String("1a"), std::vector<uint32_t>{});
 	EXPECT_EQ(ParseUInt32String("a;b;c"), std::vector<uint32_t>{});
 	EXPECT_EQ(ParseUInt32String("1"), std::vector<uint32_t>{ 1 });
 	EXPECT_EQ(ParseUInt32String("1;2"), (std::vector<uint32_t>{ 1, 2 }));
 	EXPECT_EQ(ParseUInt32String("1; 2"), (std::vector<uint32_t>{ 1, 2 }));
 	EXPECT_EQ(ParseUInt32String("1; 2 "), (std::vector<uint32_t>{ 1, 2 }));
+	EXPECT_EQ(ParseUInt32String("1 ; 2,3 , 4; "), (std::vector<uint32_t>{ 1, 2, 3, 4 }));
 }


### PR DESCRIPTION
Add new option "all but skill ids" in stats exclude to whitelist only certain skills, useful when focusing only on ressing skills on downed allies like:
- druid https://wiki.guildwars2.com/wiki/Spirit_of_Nature
- warrior https://wiki.guildwars2.com/wiki/Battle_Standard
- guardian https://wiki.guildwars2.com/wiki/Signet_of_Mercy

Or as skill ids "12601,69336,14419,9163".

mesmer https://wiki.guildwars2.com/wiki/Illusion_of_Life doesn't heal so it cannot be tracked this way.

Supported delimiters are comma, semicolon and space. An empty textbox or a textbox with just delimiters disables the filter.
This is how it looks ingame:
<img width="833" height="240" alt="image" src="https://github.com/user-attachments/assets/41bedda9-dbd6-4e45-8ebf-0ee1ac91b638" />

Some examples:
- no filter
<img width="1200" height="250" alt="image" src="https://github.com/user-attachments/assets/567e6318-b384-4643-aa17-4d13aa8919a2" />

- single skill
<img width="1199" height="252" alt="image" src="https://github.com/user-attachments/assets/ec469ae3-603c-4bf2-9897-c8c45927607d" />

- multiple skills
<img width="1172" height="240" alt="image" src="https://github.com/user-attachments/assets/5f8e2c24-673f-4971-9a50-80a0dd809704" />


Enable "debug mode" to view the skill ids
<img width="621" height="501" alt="image" src="https://github.com/user-attachments/assets/edef24c3-0157-4418-bff2-a80b8108808f" />
