### PR TITLE
Separate downed/non-downed from healing/barrier filters

### DIFF
--- a/src/AggregatedStats.cpp
+++ b/src/AggregatedStats.cpp
@@ -121,7 +121,15 @@ const AggregatedVector& AggregatedStats::GetGroupFilterTotals()
 				continue;
 			}
 		}
-		else if (curEvent.IsBarrierGeneration)
+		else // Non-downed
+		{
+			if (myOptions.ExcludeAgainstNonDowned == true)
+			{
+				continue;
+			}
+		}
+			
+		if (curEvent.IsBarrierGeneration)
 		{
 			if (myOptions.ExcludeBarrierGeneration == true)
 			{
@@ -333,7 +341,15 @@ const AggregatedVector& AggregatedStats::GetAgents(std::optional<uint32_t> pSkil
 				continue;
 			}
 		}
-		else if (curEvent.IsBarrierGeneration)
+		else // Non-downed
+		{
+			if (myOptions.ExcludeAgainstNonDowned == true)
+			{
+				continue;
+			}
+		}
+		
+		if (curEvent.IsBarrierGeneration)
 		{
 			if (myOptions.ExcludeBarrierGeneration == true)
 			{
@@ -476,7 +492,15 @@ const AggregatedVector& AggregatedStats::GetSkills(std::optional<uintptr_t> pAge
 				continue;
 			}
 		}
-		else if (curEvent.IsBarrierGeneration)
+		else // Non-downed
+		{
+			if (myOptions.ExcludeAgainstNonDowned == true)
+			{
+				continue;
+			}
+		}
+		
+		if (curEvent.IsBarrierGeneration)
 		{
 			if (myOptions.ExcludeBarrierGeneration == true)
 			{

--- a/src/GUI.cpp
+++ b/src/GUI.cpp
@@ -726,6 +726,7 @@ static void Display_WindowOptions(HealTableOptions& pHealingOptions, HealWindowC
 			ImGuiEx::SmallCheckBox("healing", &pContext.ExcludeHealing);
 			ImGuiEx::SmallCheckBox("barrier generation", &pContext.ExcludeBarrierGeneration);
 			ImGuiEx::SmallCheckBox("against downed", &pContext.ExcludeAgainstDowned);
+			ImGuiEx::SmallCheckBox("against non-downed", &pContext.ExcludeAgainstNonDowned);
 
 			ImGui::EndMenu();
 		}

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -132,7 +132,8 @@ HealTableOptions::HealTableOptions()
 	Windows[6].DataSourceChoice = DataSource::PeersOutgoing;
 	Windows[6].ExcludeHealing = true;
 	Windows[6].ExcludeBarrierGeneration = false;
-	Windows[6].ExcludeAgainstDowned = true;
+	Windows[6].ExcludeAgainstDowned = false;
+	Windows[6].ExcludeAgainstNonDowned = false;
 	snprintf(Windows[6].Name, sizeof(Windows[6].Name), "%s", "Peers barrier generation");
 	snprintf(Windows[6].TitleFormat, sizeof(Windows[6].TitleFormat), "%s", "Barrier generation {1} ({4}/s, {7}s in combat)");
 
@@ -435,6 +436,7 @@ void HealWindowOptions::FromJson(const nlohmann::json& pJsonObject)
 	GetJsonValue(pJsonObject, "ExcludeHealing", ExcludeHealing);
 	GetJsonValue(pJsonObject, "ExcludeBarrierGeneration", ExcludeBarrierGeneration);
 	GetJsonValue(pJsonObject, "ExcludeAgainstDowned", ExcludeAgainstDowned);
+	GetJsonValue(pJsonObject, "ExcludeAgainstNonDowned", ExcludeAgainstNonDowned);
 
 	GetJsonValue(pJsonObject, "ShowProgressBars", ShowProgressBars);
 	GetJsonValue(pJsonObject, "UseSubgroupForBarColour", UseSubgroupForBarColour);
@@ -503,6 +505,7 @@ do {\
 	SET_JSON_VAL(ExcludeHealing);
 	SET_JSON_VAL(ExcludeBarrierGeneration);
 	SET_JSON_VAL(ExcludeAgainstDowned);
+	SET_JSON_VAL(ExcludeAgainstNonDowned);
 
 	SET_JSON_VAL(ShowProgressBars);
 	SET_JSON_VAL(UseSubgroupForBarColour);

--- a/src/State.h
+++ b/src/State.h
@@ -60,6 +60,7 @@ struct HealWindowOptions
 	bool ExcludeHealing = false;
 	bool ExcludeBarrierGeneration = true;
 	bool ExcludeAgainstDowned = false;
+	bool ExcludeAgainstNonDowned = false;
 
 	bool ShowProgressBars = true;
 	bool UseSubgroupForBarColour = false;


### PR DESCRIPTION
Separate downed/non-downed from healing/barrier filters, so have can have all the combinations

| Exclude | Healing | Barrier |
| --- | --- | --- |
| Downed| | |
| Non-downed | | |

<img width="320" height="211" alt="image" src="https://github.com/user-attachments/assets/eeabf157-4b2e-4c98-9af9-bb3606ff40fe" />
